### PR TITLE
Process node list extension

### DIFF
--- a/messaging/src/main/java/org/cloudiator/messaging/services/ProcessService.java
+++ b/messaging/src/main/java/org/cloudiator/messaging/services/ProcessService.java
@@ -11,6 +11,8 @@ import org.cloudiator.messages.Process.LanceProcessCreatedResponse;
 import org.cloudiator.messages.Process.LanceProcessDeletedResponse;
 import org.cloudiator.messages.Process.ProcessCreatedResponse;
 import org.cloudiator.messages.Process.ProcessDeletedResponse;
+import org.cloudiator.messages.Process.ProcessGroupQueryMessage;
+import org.cloudiator.messages.Process.ProcessGroupQueryResponse;
 import org.cloudiator.messages.Process.ProcessQueryRequest;
 import org.cloudiator.messages.Process.ProcessQueryResponse;
 import org.cloudiator.messages.Process.ScheduleCreatedResponse;
@@ -85,4 +87,7 @@ public interface ProcessService {
   void subscribeCreateSparkProcessRequest(MessageCallback<CreateSparkProcessRequest> callback);
 
   void subscribeSchedule(MessageCallback<CreateScheduleRequest> callback);
+
+  ProcessGroupQueryResponse queryProcessGroups(ProcessGroupQueryMessage processGroupQueryMessage)
+      throws ResponseException;
 }

--- a/messaging/src/main/java/org/cloudiator/messaging/services/ProcessServiceImpl.java
+++ b/messaging/src/main/java/org/cloudiator/messaging/services/ProcessServiceImpl.java
@@ -13,6 +13,8 @@ import org.cloudiator.messages.Process.LanceProcessCreatedResponse;
 import org.cloudiator.messages.Process.LanceProcessDeletedResponse;
 import org.cloudiator.messages.Process.ProcessCreatedResponse;
 import org.cloudiator.messages.Process.ProcessDeletedResponse;
+import org.cloudiator.messages.Process.ProcessGroupQueryMessage;
+import org.cloudiator.messages.Process.ProcessGroupQueryResponse;
 import org.cloudiator.messages.Process.ProcessQueryRequest;
 import org.cloudiator.messages.Process.ProcessQueryResponse;
 import org.cloudiator.messages.Process.ScheduleCreatedResponse;
@@ -181,6 +183,12 @@ public class ProcessServiceImpl implements ProcessService {
   public void subscribeSchedule(MessageCallback<CreateScheduleRequest> callback) {
     messageInterface
         .subscribe(CreateScheduleRequest.class, CreateScheduleRequest.parser(), callback);
+  }
+
+  @Override
+  public ProcessGroupQueryResponse queryProcessGroups(
+      ProcessGroupQueryMessage processGroupQueryMessage) throws ResponseException {
+    return messageInterface.call(processGroupQueryMessage, ProcessGroupQueryResponse.class, timeout);
   }
 
 }

--- a/messaging/src/main/proto/process.proto
+++ b/messaging/src/main/proto/process.proto
@@ -33,8 +33,10 @@ message CreateProcessRequest {
 }
 
 message ProcessCreatedResponse {
-  Process process = 1;
+  ProcessGroup processGroup = 1;
 }
+
+
 
 message DeleteProcessRequest {
   string userId = 1;
@@ -91,4 +93,13 @@ message DeleteScheduleRequest {
 
 message ScheduleDeleteResponse {
   
+}
+
+message ProcessGroupQueryMessage {
+  string userId = 1;
+  string processGroupId = 2;
+}
+
+message ProcessGroupQueryResponse {
+  repeated ProcessGroup processGroups = 1;
 }

--- a/messaging/src/main/proto/processEntities.proto
+++ b/messaging/src/main/proto/processEntities.proto
@@ -14,13 +14,17 @@ message ProcessNew {
   string nodeGroup = 3;
 }
 
-message Process {
+message Process{
   string id = 1;
   string schedule = 2;
   string task = 3;
-  string nodeGroup = 4;
-  ProcessType type = 5;
+  oneof runsOn{
+    string node = 4;
+    string nodeGroup = 5;
+  }
+  ProcessType type = 6;
 }
+
 
 message ProcessGroup {
   string id = 1;
@@ -31,7 +35,7 @@ message LanceProcess {
   string schedule = 1;
   Job job = 2;
   string task = 3;
-  iaas.NodeGroup nodeGroup = 4;
+  iaas.Node node = 4;
 }
 
 message SparkProcess {

--- a/messaging/src/main/proto/processEntities.proto
+++ b/messaging/src/main/proto/processEntities.proto
@@ -11,15 +11,20 @@ import "nodeEntities.proto";
 message ProcessNew {
   string schedule = 1;
   string task = 2;
-  string node = 3;
+  iaas.NodeGroup nodeGroup = 3;
 }
 
 message Process {
   string id = 1;
   string schedule = 2;
   string task = 3;
-  string node = 4;
+  iaas.NodeGroup nodeGroup = 4;
   ProcessType type = 5;
+}
+
+message ProcessGroup {
+  string id = 1;
+  repeated Process process = 2;
 }
 
 message LanceProcess {
@@ -33,7 +38,7 @@ message SparkProcess {
   string schedule = 1;
   Job job = 2;
   string task = 3;
-  iaas.Node node = 4;
+  repeated iaas.Node node = 4;
 }
 
 message ScheduleNew {

--- a/messaging/src/main/proto/processEntities.proto
+++ b/messaging/src/main/proto/processEntities.proto
@@ -11,14 +11,14 @@ import "nodeEntities.proto";
 message ProcessNew {
   string schedule = 1;
   string task = 2;
-  iaas.NodeGroup nodeGroup = 3;
+  string nodeGroup = 3;
 }
 
 message Process {
   string id = 1;
   string schedule = 2;
   string task = 3;
-  iaas.NodeGroup nodeGroup = 4;
+  string nodeGroup = 4;
   ProcessType type = 5;
 }
 
@@ -31,14 +31,14 @@ message LanceProcess {
   string schedule = 1;
   Job job = 2;
   string task = 3;
-  iaas.Node node = 4;
+  iaas.NodeGroup nodeGroup = 4;
 }
 
 message SparkProcess {
   string schedule = 1;
   Job job = 2;
   string task = 3;
-  repeated iaas.Node node = 4;
+  iaas.NodeGroup nodeGroup = 4;
 }
 
 message ScheduleNew {


### PR DESCRIPTION
- added NodeGroup to Spark Process
- added ProcessGroup Message
- refactored messages to enable a group of nodes for one Process for Spark
- refactored messages to have 1:1 mapping of node to process for Lance, Docker and FaaS